### PR TITLE
Actions: allow repo write permissions

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -24,7 +24,7 @@ jobs:
     name: "Release"
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
     steps:
       - name: Checkout


### PR DESCRIPTION
This may be the reason the action is failing on step `Push changes`. The option for write access has already been enabled in the repo settings.